### PR TITLE
Corrected implementation of Markdown Widget for embedding in Html.

### DIFF
--- a/src/Native/Markdown.js
+++ b/src/Native/Markdown.js
@@ -58,24 +58,28 @@ Elm.Native.Markdown.make = function(localRuntime) {
         }
     }
 
+    function MarkdownWidget(options, rawMarkdown) {
+        this._options = options;
+        this._rawMarkdown = rawMarkdown;
+    }
+
+    MarkdownWidget.prototype.type = "Widget";
+
+    MarkdownWidget.prototype.init = function init() {
+        var html = marked(this._rawMarkdown, formatOptions(this._options));
+        var div = document.createElement('div');
+        div.innerHTML = html;
+        return div;
+    };
+
+    MarkdownWidget.prototype.update = function update(previous, node) {
+        var html = marked(this._rawMarkdown, formatOptions(this._options));
+        node.innerHTML = html;
+        return node;
+    };
+
     function toHtmlWith(options, rawMarkdown) {
-        var widget = {
-            type: "Widget",
-
-            init: function () {
-                var html = marked(rawMarkdown, formatOptions(options));
-                var div = document.createElement('div');
-                div.innerHTML = html;
-                return div;
-            },
-
-            update: function (previous, node) {
-                var html = marked(rawMarkdown, formatOptions(options));
-                node.innerHTML = html;
-                return node;
-            }
-        };
-        return widget;
+        return new MarkdownWidget(options, rawMarkdown);
     }
 
     function toElementWith(options, rawMarkdown) {


### PR DESCRIPTION
The virtual-dom library in Elm requires the methods of embedded widgets
to have shared implementations across all instances as a type checking
mechanism. So we cannot have these methods be closures created every time
a Markdown widget is used.

For more info, see https://github.com/evancz/virtual-dom/issues/9
