### PR TITLE
Extend README with info about highlight.js

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Markdown in Elm
 
-This package is for markdown parsing. It is based on the [marked][] project
+This package is for markdown parsing and rendering. It is based on the [marked][] project
 which focuses on speed.
 
 [marked]: https://github.com/chjj/marked
@@ -23,3 +23,14 @@ content = Markdown.toElement """
 whole block, so try not to call it for no reason. In the `content` example
 above we only have to parse the text once, but if we put it in a function we
 may be doing a lot of unnecessary parsing.
+
+## Code Blocks
+
+For highlighting any code blocks, the package relies on the
+[highlight.js](https://highlightjs.org/) project. So if you want to
+see highlighting of code blocks in the rendering result, you need to
+make sure that your page/app binds a version of that library
+(supporting the languages you want to handle) to `window.hljs` in
+Javascript. [This is how package.elm-lang.org does
+that.](https://github.com/elm-lang/package.elm-lang.org/blob/e0b7aa4282038475612722ff7a57195866f8645b/backend/ServeFile.hs#L54)
+


### PR DESCRIPTION
So far, the documentation of `elm-markdown` makes no reference to `highlight.js` whatsoever, despite the fact that the implementation of `elm-markdown` will look for an instance of `highlight.js` to be present in the running app (in [this line](https://github.com/evancz/elm-markdown/blob/1.1.4/src/Native/Markdown.js#L27)) and use it if it is.
