### PR TITLE
Use highlight.js's auto detection for code blocks without language tag

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,3 +34,6 @@ make sure that your page/app binds a version of that library
 Javascript. [This is how package.elm-lang.org does
 that.](https://github.com/elm-lang/package.elm-lang.org/blob/e0b7aa4282038475612722ff7a57195866f8645b/backend/ServeFile.hs#L54)
 
+For code blocks without a language tag, highlight.js's auto detection
+will be used, based on the language set you have included in the
+version of that library bound in your app.

--- a/src/Native/Markdown.js
+++ b/src/Native/Markdown.js
@@ -24,13 +24,19 @@ Elm.Native.Markdown.make = function(localRuntime) {
 
 	marked.setOptions({
 		highlight: function (code, lang) {
-			if (typeof hljs !== 'undefined'
-				&& lang
-				&& hljs.listLanguages().indexOf(lang) >= 0)
+			if (typeof hljs === 'undefined')
 			{
-				return hljs.highlight(lang, code, true).value;
+				return code;
 			}
-			return code;
+			if (lang)
+			{
+				if (hljs.listLanguages().indexOf(lang) >= 0)
+				{
+					return hljs.highlight(lang, code, true).value;
+				}
+				return code;
+			}
+			return hljs.highlightAuto(code).value;
 		}
 	});
 


### PR DESCRIPTION
Merging this will have the following consequences.

For users of  `elm-markdown`:
- If they aren't binding `highlight.js` in their app, no consequences at all.
- If they are binding `highlight.js`, but are only ever producing code blocks with explicit language tags, no consequences at all.
- If they are binding `highlight.js`, and are producing code blocks without language tags, then while previously these code blocks would have received no syntax highlighting, they will now be syntax highlighted according to what `highlight.js`'s language detection facility decides (based on the set of available languages chosen for the specific version of `highlight.js` bound).

So, very minor consequences, which moreover can be easily evaded/opted-out of. Plus, until yesterday `elm-markdown`'s use of `highlight.js` was completely undocumented, so there should be no code relying on this out there at the moment.

For http://package.elm-lang.org/:
- If recompiled with the changed version of `elm-markdown`, all untagged code blocks on the documentation pages, in particular all inline code, _should_ (if my understanding of `highlight.js`'s working is correct) receive syntax highlighting according to `highlight.js`'s language detection facility. Since the version of `highlight.js` bound in http://package.elm-lang.org/ currently includes the language set `css`, `xml`, `haskell`, `elm`, `javascript`, it seems safe to assume that this would lead to the desired Elm highlighting. (As an aside: Do we really expect to see all of `css`, `xml`, `haskell`, `elm`, `javascript` in documentation pages at http://package.elm-lang.org/? Maybe that set could be made smaller.)

In summary, this pull request should achieve the ultimate goal of https://github.com/elm-lang/package.elm-lang.org/issues/39, without bad consequences for other use(r)s of `elm-markdown`.
