### PR TITLE
Make Elm highlighting the default (for code blocks without language tag)

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,3 +34,6 @@ make sure that your page/app binds a version of that library
 Javascript. [This is how package.elm-lang.org does
 that.](https://github.com/elm-lang/package.elm-lang.org/blob/e0b7aa4282038475612722ff7a57195866f8645b/backend/ServeFile.hs#L54)
 
+For code blocks without a language tag, Elm highlighting will be used,
+if `"elm"` is in the language set you have included in the version of
+the highlight.js library bound in your app.

--- a/src/Native/Markdown.js
+++ b/src/Native/Markdown.js
@@ -24,9 +24,15 @@ Elm.Native.Markdown.make = function(localRuntime) {
 
 	marked.setOptions({
 		highlight: function (code, lang) {
-			if (typeof hljs !== 'undefined'
-				&& lang
-				&& hljs.listLanguages().indexOf(lang) >= 0)
+			if (typeof hljs === 'undefined')
+			{
+				return code;
+			}
+			if (!lang)
+			{
+				lang = "elm";
+			}
+			if (hljs.listLanguages().indexOf(lang) >= 0)
 			{
 				return hljs.highlight(lang, code, true).value;
 			}


### PR DESCRIPTION
Replaces https://github.com/evancz/elm-markdown/pull/7.

Merging this will have the following consequences.

For users of  `elm-markdown`:
- If they aren't binding `highlight.js` in their app, no consequences at all.
- If they are binding `highlight.js`, but are only ever producing code blocks with explicit language tags, no consequences at all.
- If they are binding `highlight.js`, and are producing code blocks without language tags, but have not included "elm" in the set of available languages chosen for the specific version of `highlight.js` bound (presumably because their app has no desire to highlight any Elm code), no consequences at all.
- If they are binding `highlight.js`, and the bound version of that library has "elm" in its set of available languages, and they are producing code blocks without language tags, then while previously these code blocks would have received no syntax highlighting, they will now be syntax highlighted as Elm code.

So, very minor consequences, which moreover can be easily evaded/opted-out of (by using a non-existing language tag like `xxx` for code that should not be highlighted, or by not including "elm" in highlight.js if it is not wanted). Plus, until very recently `elm-markdown`'s use of `highlight.js` was completely undocumented, so there should be no code relying on this out there at the moment (except for the package.elm-lang.org repo).

For http://package.elm-lang.org/:
- If recompiled with the changed version of `elm-markdown`, all untagged code blocks on the documentation pages, in particular all inline code, will receive the desired Elm syntax highlighting. See https://github.com/evancz/elm-markdown/pull/7#issuecomment-124731397 for an example of how this will look.

In summary, this pull request should achieve the ultimate goal of https://github.com/elm-lang/package.elm-lang.org/issues/39, without bad consequences for other use(r)s of `elm-markdown`.
