### PR TITLE
Fixing type errors in the native stuff

### DIFF
--- a/src/Native/Markdown.js
+++ b/src/Native/Markdown.js
@@ -40,8 +40,8 @@ Elm.Native.Markdown.make = function(localRuntime) {
 		{
 			return {
 				gfm: true,
-				tables: gfm.tables,
-				breaks: gfm.breaks,
+				tables: gfm._0.tables,
+				breaks: gfm._0.breaks,
 				sanitize: options.sanitize,
 				smartypants: options.smartypants
 			};


### PR DESCRIPTION
Background: The `gfm` there is a `Maybe { tables : Bool, breaks : Bool }` (from http://package.elm-lang.org/packages/evancz/elm-markdown/1.1.5/Markdown#Options). Even after having checked its constructor to be `Just`, one cannot simply access the nested record fields with `gfm.tables` and `gfm.breaks`. Instead, `gfm._0...` is needed.
