### PR TITLE
Add 'hljs' CSS class to code blocks.

### DIFF
--- a/src/Native/Markdown.js
+++ b/src/Native/Markdown.js
@@ -50,6 +50,7 @@ Elm.Native.Markdown.make = function(localRuntime) {
 		if (gfm.ctor === 'Just')
 		{
 			return {
+				langPrefix: 'hljs ', // See https://github.com/chjj/marked/pull/418#issuecomment-65939773.
 				highlight: toHighlight,
 				gfm: true,
 				tables: gfm._0.tables,
@@ -61,6 +62,7 @@ Elm.Native.Markdown.make = function(localRuntime) {
 		else
 		{
 			return {
+				langPrefix: 'hljs ', // See https://github.com/chjj/marked/pull/418#issuecomment-65939773.
 				highlight: toHighlight,
 				gfm: false,
 				tables: false,


### PR DESCRIPTION
Currently the class is not added by marked nor by highlight.js itself,
and the rendered code will lack attributes such as background colour and
others that are defined by highlight.js styles on that particular class.

This workaround is based on
https://github.com/chjj/marked/pull/418#issuecomment-65939773.
