### PR TITLE
Apply diffs to `model`, not to undefined things

### DIFF
--- a/src/Native/Markdown.js
+++ b/src/Native/Markdown.js
@@ -30,14 +30,15 @@ function render(model)
 
 function diff(a, b)
 {
-	if (a.markdown === b.markdown && a.options === b.options)
+	
+	if (a.model.markdown === b.model.markdown && a.model.options === b.model.options)
 	{
 		return null;
 	}
 
 	return {
 		applyPatch: applyPatch,
-		data: marked(b.markdown, formatOptions(b.options))
+		data: marked(b.model.markdown, formatOptions(b.model.options))
 	};
 }
 


### PR DESCRIPTION
Problem:
- Create an element which allows for input text
- Create a markdown element that should update with some input text 
- The markdown element won't get re-rendered
- The diff from the markdown was always returning that there was no difference

Solution:
- The problem was that `a.markdown` is actually `undefined`. Needed to compare `a.model.markdown` instead
- Since they were both undefined, it diffed them to have no chnages
- So, now we just grab the model first
